### PR TITLE
Add library feature 5.4.0/cheshire

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Clojure-rest-example service"
 
   :dependencies [[ch.qos.logback/logback-classic "1.1.3"]
-                 [cheshire "5.4.2"]
+                 [cheshire "5.4.0"]
                  [clj-http "1.1.2"]
                  [clj-time "0.9.0"]
                  [compojure "1.3.4"]


### PR DESCRIPTION
update wsbforg/clojure-rest-example to use version 5.4.0 of cheshire